### PR TITLE
Enumerate all and only downloaded subdirectories

### DIFF
--- a/src/utils/install.rs
+++ b/src/utils/install.rs
@@ -266,8 +266,6 @@ async fn install_unitas(game_dir: &Path, unitas_version: DownloadVersion) -> Res
             )),
     };
 
-    let dest_dir = game_dir.join("BepInEx");
-
     // enumerate over the downloaded directories
     let source_dest_dirs = {
         let mut source_dest_dirs = Vec::new();
@@ -279,7 +277,7 @@ async fn install_unitas(game_dir: &Path, unitas_version: DownloadVersion) -> Res
             if let Ok(entry) = entry {
                 source_dest_dirs.push((
                     entry.path(),
-                    dest_dir.join(entry.path().strip_prefix(&unitas_dir).with_context(|| {
+                    game_dir.join(entry.path().strip_prefix(&unitas_dir).with_context(|| {
                         format!(
                             "Could not determine destination path for {}",
                             entry.path().display()

--- a/src/utils/install.rs
+++ b/src/utils/install.rs
@@ -243,7 +243,7 @@ async fn install_unitas(game_dir: &Path, unitas_version: DownloadVersion) -> Res
                     };
                     let file_name = file_name.to_string_lossy().to_string();
                     if file_name.starts_with(UNITAS_BEPINEX_DIR) {
-                        Some(path.join(file_name))
+                        Some(path)
                     } else {
                         None
                     }
@@ -271,7 +271,7 @@ async fn install_unitas(game_dir: &Path, unitas_version: DownloadVersion) -> Res
     let source_dest_dirs = [
         (
             unitas_dir.join(paths::unitas_plugins_dir()),
-            (dest_dir.join("plugins").join("UniTAS")),
+            (dest_dir.join("plugins").join("UniTAS")), // this doesn't exist in the stable version
         ),
         (
             unitas_dir.join(paths::unitas_patchers_dir()),

--- a/src/utils/install.rs
+++ b/src/utils/install.rs
@@ -271,7 +271,7 @@ async fn install_unitas(game_dir: &Path, unitas_version: DownloadVersion) -> Res
     let source_dest_dirs = [
         (
             unitas_dir.join(paths::unitas_plugins_dir()),
-            (dest_dir.join("plugins").join("UniTAS")), // this doesn't exist in the stable version
+            (dest_dir.join("plugins").join("UniTAS")),
         ),
         (
             unitas_dir.join(paths::unitas_patchers_dir()),

--- a/src/utils/install.rs
+++ b/src/utils/install.rs
@@ -270,24 +270,21 @@ async fn install_unitas(game_dir: &Path, unitas_version: DownloadVersion) -> Res
 
     // enumerate over the downloaded directories
     let source_dest_dirs = {
-        let mut source_dest_dirs = Vec::new(); 
-        
-        for entry 
-            in unitas_dir.read_dir().with_context(|| 
-                format!("unable to read from {}", unitas_dir.display())
-            )?
+        let mut source_dest_dirs = Vec::new();
+
+        for entry in unitas_dir
+            .read_dir()
+            .with_context(|| format!("unable to read from {}", unitas_dir.display()))?
         {
             if let Ok(entry) = entry {
                 source_dest_dirs.push((
                     entry.path(),
-                    dest_dir.join(
-                        entry
-                            .path()
-                            .strip_prefix(&unitas_dir)
-                            .with_context(|| 
-                                format!("Could not determine destination path for {}", entry.path().display())
-                            )?
-                    ),
+                    dest_dir.join(entry.path().strip_prefix(&unitas_dir).with_context(|| {
+                        format!(
+                            "Could not determine destination path for {}",
+                            entry.path().display()
+                        )
+                    })?),
                 ))
             }
         }

--- a/src/utils/install.rs
+++ b/src/utils/install.rs
@@ -190,13 +190,7 @@ async fn install_bepinex(
             );
             if bepinex_path.is_dir() {
                 debug!("{} is a dir", bepinex_path.display());
-                utils::fs::copy_dir_all(&bepinex_path, &dest_path, true).with_context(|| {
-                    format!(
-                        "Could not copy BepInEx folder from {} to {}",
-                        bepinex_path.display(),
-                        dest_path.display()
-                    )
-                })?;
+                utils::fs::copy_dir_all(&bepinex_path, &dest_path, true)?;
             } else {
                 debug!("{} is a file", bepinex_path.display());
                 fs::copy(&bepinex_path, &dest_path).with_context(|| {
@@ -286,13 +280,7 @@ async fn install_unitas(game_dir: &Path, unitas_version: DownloadVersion) -> Res
             dest_dir.display()
         );
 
-        utils::fs::copy_dir_all(&source_dir, &dest_dir, true).with_context(|| {
-            format!(
-                "Could not copy UniTAS folder from {} to {}",
-                source_dir.display(),
-                dest_dir.display()
-            )
-        })?;
+        utils::fs::copy_dir_all(&source_dir, &dest_dir, true)?;
     }
 
     Ok(())

--- a/src/utils/install.rs
+++ b/src/utils/install.rs
@@ -268,16 +268,32 @@ async fn install_unitas(game_dir: &Path, unitas_version: DownloadVersion) -> Res
 
     let dest_dir = game_dir.join("BepInEx");
 
-    let source_dest_dirs = [
-        (
-            unitas_dir.join(paths::unitas_plugins_dir()),
-            (dest_dir.join("plugins").join("UniTAS")),
-        ),
-        (
-            unitas_dir.join(paths::unitas_patchers_dir()),
-            (dest_dir.join("patchers").join("UniTAS")),
-        ),
-    ];
+    // enumerate over the downloaded directories
+    let source_dest_dirs = {
+        let mut source_dest_dirs = Vec::new(); 
+        
+        for entry 
+            in unitas_dir.read_dir().with_context(|| 
+                format!("unable to read from {}", unitas_dir.display())
+            )?
+        {
+            if let Ok(entry) = entry {
+                source_dest_dirs.push((
+                    entry.path(),
+                    dest_dir.join(
+                        entry
+                            .path()
+                            .strip_prefix(&unitas_dir)
+                            .with_context(|| 
+                                format!("Could not determine destination path for {}", entry.path().display())
+                            )?
+                    ),
+                ))
+            }
+        }
+
+        source_dest_dirs
+    };
 
     for (source_dir, dest_dir) in source_dest_dirs {
         debug!(
@@ -285,11 +301,6 @@ async fn install_unitas(game_dir: &Path, unitas_version: DownloadVersion) -> Res
             source_dir.display(),
             dest_dir.display()
         );
-
-        if !source_dir.exists() {
-            error!("{} does not exist; skipping", source_dir.display());
-            continue;
-        }
 
         utils::fs::copy_dir_all(&source_dir, &dest_dir, true).with_context(|| {
             format!(

--- a/src/utils/install.rs
+++ b/src/utils/install.rs
@@ -286,6 +286,11 @@ async fn install_unitas(game_dir: &Path, unitas_version: DownloadVersion) -> Res
             dest_dir.display()
         );
 
+        if !source_dir.exists() {
+            error!("{} does not exist; skipping", source_dir.display());
+            continue;
+        }
+
         utils::fs::copy_dir_all(&source_dir, &dest_dir, true).with_context(|| {
             format!(
                 "Could not copy UniTAS folder from {} to {}",

--- a/src/utils/install.rs
+++ b/src/utils/install.rs
@@ -287,12 +287,12 @@ async fn install_unitas(game_dir: &Path, unitas_version: DownloadVersion) -> Res
         );
 
         utils::fs::copy_dir_all(&source_dir, &dest_dir, true).with_context(|| {
-        format!(
-            "Could not copy UniTAS folder from {} to {}",
-            source_dir.display(),
-            dest_dir.display()
-        )
-    })?;
+            format!(
+                "Could not copy UniTAS folder from {} to {}",
+                source_dir.display(),
+                dest_dir.display()
+            )
+        })?;
     }
 
     Ok(())

--- a/src/utils/install.rs
+++ b/src/utils/install.rs
@@ -190,7 +190,13 @@ async fn install_bepinex(
             );
             if bepinex_path.is_dir() {
                 debug!("{} is a dir", bepinex_path.display());
-                utils::fs::copy_dir_all(&bepinex_path, &dest_path, true)?;
+                utils::fs::copy_dir_all(&bepinex_path, &dest_path, true).with_context(|| {
+                    format!(
+                        "Could not copy BepInEx folder from {} to {}",
+                        bepinex_path.display(),
+                        dest_path.display()
+                    )
+                })?;
             } else {
                 debug!("{} is a file", bepinex_path.display());
                 fs::copy(&bepinex_path, &dest_path).with_context(|| {
@@ -280,7 +286,13 @@ async fn install_unitas(game_dir: &Path, unitas_version: DownloadVersion) -> Res
             dest_dir.display()
         );
 
-        utils::fs::copy_dir_all(&source_dir, &dest_dir, true)?;
+        utils::fs::copy_dir_all(&source_dir, &dest_dir, true).with_context(|| {
+        format!(
+            "Could not copy UniTAS folder from {} to {}",
+            source_dir.display(),
+            dest_dir.display()
+        )
+    })?;
     }
 
     Ok(())

--- a/src/utils/paths/mod.rs
+++ b/src/utils/paths/mod.rs
@@ -50,11 +50,6 @@ pub fn unitas_plugins_dir() -> PathBuf {
     Path::new("plugins").join("UniTAS")
 }
 
-/// A path to the directory where UniTAS patchers are in an artifact.
-pub fn unitas_patchers_dir() -> PathBuf {
-    Path::new("patchers").join("UniTAS")
-}
-
 pub const TAG_DIR_NAME: &str = "tag";
 pub const BRANCH_DIR_NAME: &str = "branch";
 pub const STABLE_DIR_NAME: &str = "stable";


### PR DESCRIPTION
This PR addresses item 2 of #58 by enumerating over every item in the source directory, allowing for the download contents to change significantly. There are a couple of design considerations here:

1. Should we only copy over subdirectories, or every entry in a directory? currently this PR does the latter. 
2. Should there be user-facing warnings if an expected subdirectory (e.g. plugins) is missing? What if there's a directory/file we normally wouldn't expect?

I also removed unitas_patchers_dir() since it was only used in source_dest_dirs.